### PR TITLE
Add support for specifying project paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,17 @@ Include this in the tools section of your project.json. It's available via nuget
 }
 ```
 
-To change the version listed in the project.json from the command line, make sure your working directory is your project root. Then call `dotnet version set --new-version <version_number>`. You can also use an environment variable to set the version by calling `dotnet version set --env-var <variable_name>`. This is particularly useful in the project.json scripts section, where environment variables will not be resolved.
+To change the version listed in the project.json from the command line. Then call `dotnet version set --new-version <version_number> <project_path>`. You can also use an environment variable to set the version by calling `dotnet version set --env-var <variable_name> <project_path>`. This is particularly useful in the project.json scripts section, where environment variables will not be resolved.
 
-Then from the command prompt, change your working directory to the root of your project. For example if your `project.json` is in `C:\Users\Paul\Project`, you would `cd C:\Users\Paul\Project`. You can then change the version string in the `project.json` with `dotnet version <yourversionnumber>`.
+You can change the version string in the `project.json` with `dotnet version <yourversionnumber> <pathtoproject>`.
 
 The primary purpose of this is build servers. the build script might do something like this:
 ```batch
-dotnet version set --new-version 1.3.0
+dotnet version set --new-version 1.3.0 ./ProjectName/
 dotnet pack -c Release
 git commit -a -m "Release 1.3.0"
 git tag 1.3.0
-dotnet version set --new-version 1.3.1-*
+dotnet version set --new-version 1.3.1-*  ./ProjectName2/project.json
 git commit -a -m "Next working version"
 ```
 This would set the version to 1.3.0, then build and pack the project.

--- a/dotnet-version/Program.cs
+++ b/dotnet-version/Program.cs
@@ -28,8 +28,11 @@ namespace dotnet_version
 
                 target.HelpOption("-? | -help");
 
+                var paths = target.Argument("path", "If specified, the relative path(s) to the project(s)", true);
+
                 target.OnExecute(() =>
                 {
+                    var pathList = paths.Values;
                     if (newVersion.HasValue() == envVar.HasValue())
                     {
                         Logger.LogError("--new-version or --env-var must be set, not both.");
@@ -37,17 +40,19 @@ namespace dotnet_version
                     }
                     var versionString = envVar.HasValue() ? Environment.GetEnvironmentVariable(envVar.Value()) : newVersion.Value();
                     if(!string.IsNullOrWhiteSpace(versionString))
-                        SetVersion(versionString);
+                        SetVersion(versionString, pathList);
                     return 0;
                 });
             });
 
             app.Command("read", target =>
             {
+
+                var paths = target.Argument("path", "If specified, the relative path to the project", false);
                 target.HelpOption("-? | -help");
                 target.OnExecute(() =>
                 {
-                    ReadVersion();
+                    ReadVersion(paths.Values);
                     return 0;
                 });
             });
@@ -57,19 +62,47 @@ namespace dotnet_version
             return app.Execute(args);
         }
 
-        private static void ReadVersion()
+        private static IEnumerable<string> ProjectFiles(IEnumerable<string> paths)
         {
-            var projectFilePath = $"{Directory.GetCurrentDirectory()}{Path.DirectorySeparatorChar}{Project.FileName}";
+            if (!paths.Any())
+            {
+                var localPath = Path.Combine(Directory.GetCurrentDirectory(), Project.FileName);
+                if (File.Exists(localPath))
+                {
+                    yield return localPath;
+                }
+            }
+            else
+            {
+                var fullPaths = paths.Select(x => Path.GetFullPath(x));
+                var directToProjectFiles = fullPaths.Where(x => Path.GetFileName(x).Equals(Project.FileName));
+                var folderPaths = fullPaths.Where(x => !directToProjectFiles.Contains(x)).Where(x => Directory.Exists(x));
+                var folderProjectPaths = folderPaths.Select(x => Path.Combine(x, Project.FileName));
+                var foundProjects = directToProjectFiles.Union(folderProjectPaths).Where(x=> File.Exists(x));
+                foreach(var p in foundProjects)
+                {
+                    yield return p;
+                }
+            }
+        }
+
+        private static void ReadVersion(IEnumerable<string> paths)
+        {
+            var projectFilePath = ProjectFiles(paths).FirstOrDefault();
+            
             dynamic projectFile = JsonConvert.DeserializeObject(File.ReadAllText(projectFilePath));
             Console.WriteLine(projectFile.version);
         }
 
-        public static void SetVersion(string newVersion)
+        public static void SetVersion(string newVersion, IEnumerable<string> paths)
         {
-            var projectFilePath = $"{Directory.GetCurrentDirectory()}{Path.DirectorySeparatorChar}{Project.FileName}";
-            dynamic projectFile = JsonConvert.DeserializeObject(File.ReadAllText(projectFilePath));
-            projectFile.version = $"{newVersion}-*";
-            File.WriteAllText(projectFilePath, JsonConvert.SerializeObject(projectFile, Formatting.Indented));
+            //lets figure out the correct paths from the paths list
+            foreach (var projectFilePath in ProjectFiles(paths))
+            {
+                dynamic projectFile = JsonConvert.DeserializeObject(File.ReadAllText(projectFilePath));
+                projectFile.version = $"{newVersion}-*";
+                File.WriteAllText(projectFilePath, JsonConvert.SerializeObject(projectFile, Formatting.Indented));
+            }
         }
     }
 }


### PR DESCRIPTION
I've added support for specifying the path to the projects so you will be able to change the version numbers without having to `cd` into the project folder.